### PR TITLE
Fix bug in composition that allowed unapplied functions where their return value was expected

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -46,8 +46,12 @@ function checkFunction(functionBlock) {
   }
 }
 
-function matchType(block1, block2) {
+function matchCompositionType(block1, block2) {
   return block1.inputList[0].connection.checkType(block2.outputConnection)
+}
+
+function matchApplyType(block1, block2) {
+  return block1.inputList[0].connection.checkType({ check_: [functionType(block2)] })
 }
 
 function checkCompositionParam(param) {
@@ -58,14 +62,14 @@ function checkCompositionParam(param) {
 }
 
 function checkComposition(block1, block2) {
-  if (!matchType(block1, block2)) {
+  if (!matchCompositionType(block1, block2)) {
     bump(block1)
     bump(block2)
   }
 }
 
 function checkApply(block1, block2) {
-  if (!matchType(block1, block2)) {
+  if (!matchApplyType(block1, block2)) {
     bump(block2)
   }
 }


### PR DESCRIPTION
## Problem

Both `not . not $ even` and `not . not $ even 0` were valid, when only the second should be.

## Fix

Change the way we check types in `onChangeComposition`, given the composition
`f . g $ value`, before we were checking the match between the types of `f` and `g` the same way as the types of `g` and `value`. Changed that so the checks between functions on a composition and the check between the value and the function are different.