### PR TITLE
Parametric type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+index.html

--- a/functions.js
+++ b/functions.js
@@ -1,8 +1,3 @@
-function applyEven(functionBlock) {
-  functionBlock.setColour(30);
-  functionBlock.getChildren().forEach((it) => it.setColour(30))
-}
-
 const isBlockInput = input => input.type === 1
 
 const isEmptyInput = input => !input.connection.targetConnection
@@ -23,8 +18,8 @@ const functionTypeToList = functionType => functionType.split('->')
 function functionType(functionBlock) {
   const inputTypes = functionBlock.inputList
     .filter(isEmptyBlockInput)
-    .map(input => getTypeInput(input))
-  return asFunctionType(...inputTypes, getType(functionBlock.outputConnection))
+    .map(input => getInputType(input))
+  return asFunctionType(...inputTypes, getOutputType(functionBlock))
 }
 
 function outputFunctionType(functionBlock) {
@@ -46,13 +41,22 @@ function typeVariables(functionBlock) {
   return typeMap
 }
 
-function getTypeInput(input) {
+function getInputType(input) {
   if (input.parametricType) {
     const typeMap = typeVariables(input.getSourceBlock())
     return typeMap[input.parametricType] || input.parametricType
   }
 
   return getType(input.connection)
+}
+
+function getOutputType(block) {
+  if (block.parametricType) {
+    const typeMap = typeVariables(block)
+    return typeMap[block.parametricType] || block.parametricType
+  }
+
+  return getType(block.outputConnection)
 }
 
 function getType(connection) {
@@ -64,7 +68,7 @@ function checkConnectionType(connection, block, getType = functionType) {
 }
 
 function checkInputType(input, block) {
-  const inputType = getTypeInput(input)
+  const inputType = getInputType(input)
   const blockType = functionType(block)
   return inputType != 'Error' && blockType != 'Error' && (
     inputType == 'Any' || blockType == 'Any'
@@ -231,6 +235,24 @@ Blockly.Blocks['compare'] = {
     //Parametric Type
     this.inputList[0].parametricType = 'a'
     this.inputList[1].parametricType = 'a'
+  }
+}
+
+Blockly.Blocks['id'] = {
+  init: function () {
+    this.appendValueInput("PARAM")
+      .appendField("id");
+
+    this.setInputsInline(true);
+    this.setOutput(true);
+    this.setColour(230);
+    this.setTooltip("");
+    this.setHelpUrl("");
+    this.setOnChange(onChangeFunction.bind(this))
+
+    //Parametric Type
+    this.inputList[0].parametricType = 'a'
+    this.parametricType = 'a'
   }
 }
 

--- a/functions.js
+++ b/functions.js
@@ -78,17 +78,17 @@ function bump(block) {
   block.bumpNeighbours()
 }
 
-function firstEmptyFree(block) {
+function firstEmptyInput(block) {
   return block.inputList.filter(isEmptyBlockInput)[0]
 }
 
 function matchCompositionType(block1, block2) {
-  const input = firstEmptyFree(block1)
+  const input = firstEmptyInput(block1)
   return input && checkConnectionType(input.connection, block2, outputFunctionType)
 }
 
 function matchApplyType(block1, block2) {
-  const input = firstEmptyFree(block1)
+  const input = firstEmptyInput(block1)
   return input && checkConnectionType(input.connection, block2)
 }
 

--- a/functions.js
+++ b/functions.js
@@ -18,7 +18,7 @@ const isEmptyBlockInput = input => isBlockInput(input) && isEmptyInput(input)
 function functionType(functionBlock) {
   const inputTypes = functionBlock.inputList
     .filter(isEmptyBlockInput)
-    .map(input => getType(input.connection))
+    .map(input => getTypeInput(input))
   return asFunctionType(...inputTypes, getType(functionBlock.outputConnection))
 }
 
@@ -26,6 +26,10 @@ function outputFunctionType(functionBlock) {
   const type = functionType(functionBlock)
   if (!isFunction(type)) return null
   return asFunctionType(...functionTypeToList(type).slice(1))
+}
+
+function getTypeInput(input) {
+  return input.parametricType || getType(input.connection)
 }
 
 function getType(connection) {
@@ -179,11 +183,9 @@ Blockly.Blocks['charAt'] = {
 
 Blockly.Blocks['compare'] = {
   init: function () {
-    this.appendValueInput("NAME")
-      .setCheck("Number")
+    this.appendValueInput("LEFT")
       
-    this.appendValueInput("NAME")
-      .setCheck("Number")
+    this.appendValueInput("RIGHT")
       .appendField(">");//TODO: Selector
 
     this.setInputsInline(true);
@@ -192,6 +194,10 @@ Blockly.Blocks['compare'] = {
     this.setTooltip("");
     this.setHelpUrl("");
     this.setOnChange(onChangeFunction.bind(this))
+    
+    //Parametric Type
+    this.inputList[0].parametricType = 'a'
+    this.inputList[1].parametricType = 'a'
   }
 }
 

--- a/functions.js
+++ b/functions.js
@@ -14,22 +14,17 @@ const isFullyBlockInput = input => isBlockInput(input) && !isEmptyInput(input)
 
 const isFunction = type => type.includes("->")
 
+const isVarType = type => type == type.toLowerCase()
+
 const asFunctionType = (...types) => types.join('->')
 
 const functionTypeToList = functionType => functionType.split('->')
 
-function inferType(type, typeMap) {
-  return Object.entries(typeMap)
-    .reduce((type, [param, value]) => type.replace(param, value), type)
-}
-
 function functionType(functionBlock) {
-  const typeMap = typeVariables(functionBlock)
   const inputTypes = functionBlock.inputList
     .filter(isEmptyBlockInput)
     .map(input => getTypeInput(input))
-  const parametricType = asFunctionType(...inputTypes, getType(functionBlock.outputConnection))
-  return inferType(parametricType, typeMap)
+  return asFunctionType(...inputTypes, getType(functionBlock.outputConnection))
 }
 
 function outputFunctionType(functionBlock) {
@@ -46,21 +41,36 @@ function typeVariables(functionBlock) {
     .forEach(input => {
       const typeVar = input.parametricType
       const type = getType(input.connection.targetConnection)
-      typeMap[typeVar] = type //TODO: Type check? 
+      typeMap[typeVar] = typeMap[typeVar] && typeMap[typeVar] != type ? "ERROR" : type  //TODO: Type check? 
     })
   return typeMap
 }
 
 function getTypeInput(input) {
-  return input.parametricType || getType(input.connection)
+  if (input.parametricType) {
+    const typeMap = typeVariables(input.getSourceBlock())
+    return typeMap[input.parametricType] || input.parametricType
+  }
+
+  return getType(input.connection)
 }
 
 function getType(connection) {
   return connection.getCheck() && connection.getCheck()[0] || 'Any'
 }
 
-function checkType(connection, block, getType = functionType) {
+function checkConnectionType(connection, block, getType = functionType) {
   return connection.checkType({ check_: [getType(block)] })
+}
+
+function checkInputType(input, block) {
+  const inputType = getTypeInput(input)
+  const blockType = functionType(block)
+  return inputType != 'Error' && blockType != 'Error' && (
+    inputType == 'Any' || blockType == 'Any'
+    || isVarType(inputType) || isVarType(blockType)
+    || inputType == blockType //TODO: Match types
+  )
 }
 
 function bump(block) {
@@ -74,17 +84,17 @@ function firstEmptyFree(block) {
 
 function matchCompositionType(block1, block2) {
   const input = firstEmptyFree(block1)
-  return input && checkType(input.connection, block2, outputFunctionType)
+  return input && checkConnectionType(input.connection, block2, outputFunctionType)
 }
 
 function matchApplyType(block1, block2) {
   const input = firstEmptyFree(block1)
-  return input && checkType(input.connection, block2)
+  return input && checkConnectionType(input.connection, block2)
 }
 
-function checkParentConnection(functionBlock) {
-  if (functionBlock.outputConnection.targetConnection && !checkType(functionBlock.outputConnection.targetConnection, functionBlock)) {
-    bump(functionBlock)
+function checkParentConnection(block) {
+  if (block.outputConnection.targetConnection && !checkInputType(block.outputConnection.targetConnection.getParentInput(), block)) {
+    bump(block)
   }
 }
 
@@ -246,11 +256,11 @@ Blockly.Blocks['composition'] = {
 Blockly.Blocks["math_arithmetic"].onchange = function (event) { onChangeFunction.bind(this)(event) }
 Blockly.Blocks["math_number"].onchange = function (event) {
   if (event.blockId == this.id) {
-    if (!this.getParent()) {
-      this.setColour(230)
-    } else {
-      this.setColour(30)
-    }
-
+    checkParentConnection(this)
+  }
+}
+Blockly.Blocks["text"].onchange = function (event) {
+  if (event.blockId == this.id) {
+    checkParentConnection(this)
   }
 }

--- a/functions.js
+++ b/functions.js
@@ -70,11 +70,17 @@ function checkConnectionType(connection, block, getType = functionType) {
 function checkInputType(input, block) {
   const inputType = getInputType(input)
   const blockType = functionType(block)
-  return inputType != 'Error' && blockType != 'Error' && (
-    inputType == 'Any' || blockType == 'Any'
-    || isVarType(inputType) || isVarType(blockType)
-    || inputType == blockType //TODO: Match types
-  )
+  const types = [inputType, blockType]
+  return !types.includes('Error') && (types.includes('Any') || matchTypes(...types))
+}
+
+function matchTypes(inputType, blockType) {
+  return structuralMatch(inputType, blockType) && //TODO: compare by structural for higher order
+    (isVarType(inputType) || isVarType(blockType) || inputType == blockType)
+}
+
+function structuralMatch(inputType, blockType) {
+  return functionTypeToList(inputType).length === functionTypeToList(blockType).length
 }
 
 function bump(block) {

--- a/functions.js
+++ b/functions.js
@@ -35,8 +35,10 @@ function typeVariables(functionBlock) {
     .filter(input => input.parametricType)
     .forEach(input => {
       const typeVar = input.parametricType
-      const type = getType(input.connection.targetConnection)
-      typeMap[typeVar] = typeMap[typeVar] && typeMap[typeVar] != type ? "ERROR" : type  //TODO: Type check? 
+      const type = functionType(input.connection.targetConnection.getSourceBlock())
+      if (type != 'Any') {
+        typeMap[typeVar] = typeMap[typeVar] && typeMap[typeVar] != type ? 'ERROR' : type  //TODO: Type check? 
+      }
     })
   return typeMap
 }

--- a/index.md
+++ b/index.md
@@ -9,6 +9,7 @@
 
 <xml id="toolbox" style="display: none">
   <block type="composition"></block>
+  <block type="id"></block>
   <block type="even"></block>
   <block type="not"></block>
   <block type="length"></block>

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@
 <script src="blockly/msg/js/es.js"></script>
 <script src="functions.js"></script>
 
-<div id="blocklyDiv" style="height: 480px; width: 600px;"></div>
+<div id="blocklyDiv"></div>
 
 <xml id="toolbox" style="display: none">
   <block type="composition"></block>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "<script src=\"blockly/blockly_compressed.js\"></script> <script src=\"blockly/blocks_compressed.js\"></script> <script src=\"blockly/msg/js/es.js\"></script> <script src=\"functions.js\"></script>",
   "main": "functions.js",
   "scripts": {
+    "start": "rm index.html && cat index.md >> index.html",
     "test": "mocha-headless-chrome -f test/test.html"
   },
   "repository": {

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -42,6 +42,15 @@ describe('Connections', () => {
       assertRejectedConnection(not, even)
     })
 
+    onWorkspace('should not connect unexpected parameters functions with parametric type', workspace => {
+      const not = workspace.newBlock('not')
+      const id = workspace.newBlock('id')
+
+      connect(not, id)
+
+      assertRejectedConnection(not, id)
+    })
+
     describe('with parametric type', () => {
       onWorkspace('should connect matching types', workspace => {
         const compare = workspace.newBlock('compare')

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -42,6 +42,27 @@ describe('Connections', () => {
       assertRejectedConnection(not, even)
     })
 
+    describe('with parametric type', () => {
+      onWorkspace('should connect matching types', workspace => {
+        const compare = workspace.newBlock('compare')
+        const number = workspace.newBlock('math_number')
+        const otherNumber = workspace.newBlock('math_number')
+        connect(compare, number, 0)
+        connect(compare, otherNumber, 1)
+        assertConnection(compare, number)
+        assertConnection(compare, otherNumber)
+      })
+
+      onWorkspace('should not connect not matching types', workspace => {
+        const compare = workspace.newBlock('compare')
+        const number = workspace.newBlock('math_number')
+        const text = workspace.newBlock('text')
+        connect(compare, number, 0)
+        connect(compare, text, 1)
+        assertConnection(compare, number)
+        assertRejectedConnection(compare, text)
+      })
+    })
   })
 
 
@@ -91,7 +112,7 @@ describe('Connections', () => {
 
       assertRejectedConnection(composition, number)
     })
-    
+
     onWorkspace('should connect compositionable functions', workspace => {
       const composition = workspace.newBlock('composition')
       const not = workspace.newBlock('not')
@@ -160,10 +181,10 @@ describe('Connections', () => {
         const composition = workspace.newBlock('composition')
         const charAt = workspace.newBlock('charAt')
         const length = workspace.newBlock('length')
-  
+
         connect(composition, charAt, 0)
         connect(composition, length, 1)
-  
+
         assertConnection(composition, charAt)
         assertConnection(composition, length)
       })
@@ -173,11 +194,11 @@ describe('Connections', () => {
         const not = workspace.newBlock('not')
         const compare = workspace.newBlock('compare')
         const number = workspace.newBlock('math_number')
-  
+
         connect(compare, number, 0)
         connect(composition, not, 0)
         connect(composition, compare, 1)
-  
+
         assertConnection(composition, not)
         assertConnection(composition, compare)
       })
@@ -187,25 +208,25 @@ describe('Connections', () => {
         const not = workspace.newBlock('not')
         const compare = workspace.newBlock('compare')
         const number = workspace.newBlock('math_number')
-  
+
         connect(compare, number, 1)
         connect(composition, not, 0)
         connect(composition, compare, 1)
-  
+
         assertConnection(composition, not)
         assertConnection(composition, compare)
       })
-  
+
       onWorkspace('should not connect non compositionable functions', workspace => {
         const composition = workspace.newBlock('composition')
         const charAt = workspace.newBlock('charAt')
         const length = workspace.newBlock('length')
         const number = workspace.newBlock('math_number')
-  
+
         connect(charAt, number, 0)
         connect(composition, charAt, 0)
         connect(composition, length, 1)
-  
+
         assertRejectedConnection(composition, charAt)
         assertRejectedConnection(composition, length)
       })
@@ -215,27 +236,27 @@ describe('Connections', () => {
         const charAt = workspace.newBlock('charAt')
         const number = workspace.newBlock('math_number')
         const text = workspace.newBlock('text')
-  
+
         connect(charAt, number, 0)
         connect(composition, charAt, 1)
         connect(composition, text, 2)
-  
+
         assertConnection(composition, text)
       })
-  
+
       onWorkspace('should not connect unexpected value', workspace => {
         const composition = workspace.newBlock('composition')
         const charAt = workspace.newBlock('charAt')
         const number = workspace.newBlock('math_number')
         const otherNumber = workspace.newBlock('math_number')
-  
+
         connect(charAt, number, 0)
         connect(composition, charAt, 1)
         connect(composition, otherNumber, 2)
-  
+
         assertRejectedConnection(composition, otherNumber)
       })
-  
+
     })
   })
 })

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -42,15 +42,6 @@ describe('Connections', () => {
       assertRejectedConnection(not, even)
     })
 
-    onWorkspace('should not connect unexpected parameters functions with parametric type', workspace => {
-      const not = workspace.newBlock('not')
-      const id = workspace.newBlock('id')
-
-      connect(not, id)
-
-      assertRejectedConnection(not, id)
-    })
-
     describe('with parametric type', () => {
       onWorkspace('should connect matching types', workspace => {
         const compare = workspace.newBlock('compare')
@@ -70,6 +61,65 @@ describe('Connections', () => {
         connect(compare, text, 1)
         assertConnection(compare, number)
         assertRejectedConnection(compare, text)
+      })
+
+      onWorkspace('should connect expected parameters applied functions', workspace => {
+        const length = workspace.newBlock('length')
+        const id = workspace.newBlock('id')
+        const text = workspace.newBlock('text')
+  
+        connect(id, text)
+        connect(length, id)
+  
+        assertConnection(length, id)
+      })
+
+      onWorkspace('should not connect unexpected parameters functions', workspace => {
+        const not = workspace.newBlock('not')
+        const id = workspace.newBlock('id')
+  
+        connect(not, id)
+  
+        assertRejectedConnection(not, id)
+      })
+
+      onWorkspace('should not connect unexpected parameters applied functions', workspace => {
+        const not = workspace.newBlock('not')
+        const id = workspace.newBlock('id')
+        const text = workspace.newBlock('text')
+  
+        connect(id, text)
+        connect(not, id)
+  
+        assertRejectedConnection(not, id)
+      })
+      
+      onWorkspace('should connect advanced matching types', workspace => {
+        const compare = workspace.newBlock('compare')
+        const id = workspace.newBlock('id')
+        const number = workspace.newBlock('math_number')
+        const otherId = workspace.newBlock('id')
+        const otherNumber = workspace.newBlock('math_number')
+        connect(id, number)
+        connect(otherId, otherNumber)
+        connect(compare, id, 0)
+        connect(compare, otherId, 1)
+        assertConnection(compare, id)
+        assertConnection(compare, otherId)
+      })
+
+      onWorkspace('should not connect advanced not matching types', workspace => {
+        const compare = workspace.newBlock('compare')
+        const id = workspace.newBlock('id')
+        const number = workspace.newBlock('math_number')
+        const otherId = workspace.newBlock('id')
+        const text = workspace.newBlock('text')
+        connect(id, number)
+        connect(otherId, text)
+        connect(compare, id, 0)
+        connect(compare, otherId, 1)
+        assertRejectedConnection(compare, id)
+        assertConnection(compare, otherId)
       })
     })
   })

--- a/test/typeSpec.js
+++ b/test/typeSpec.js
@@ -47,6 +47,15 @@ describe('Types', () => {
 
   })
 
+  describe('parametric type', () => {
+
+    onWorkspace('compare', workspace => {
+      const compare = workspace.newBlock('compare')
+      assertType(compare, 'a', 'a', 'Boolean')
+    })
+
+  })
+
   describe('composition', () => {
 
     onWorkspace('type', workspace => {

--- a/test/typeSpec.js
+++ b/test/typeSpec.js
@@ -49,11 +49,17 @@ describe('Types', () => {
 
   describe('parametric type', () => {
 
-    onWorkspace('compare', workspace => {
+    onWorkspace('full type', workspace => {
       const compare = workspace.newBlock('compare')
       assertType(compare, 'a', 'a', 'Boolean')
     })
 
+    onWorkspace('inferred type', workspace => {
+      const compare = workspace.newBlock('compare')
+      const number = workspace.newBlock('math_number')
+      connect(compare, number, 0)
+      assertType(compare, 'Number', 'Boolean')
+    })
   })
 
   describe('composition', () => {

--- a/test/typeSpec.js
+++ b/test/typeSpec.js
@@ -49,16 +49,28 @@ describe('Types', () => {
 
   describe('parametric type', () => {
 
-    onWorkspace('full type', workspace => {
+    onWorkspace('input parametric type', workspace => {
       const compare = workspace.newBlock('compare')
       assertType(compare, 'a', 'a', 'Boolean')
     })
 
-    onWorkspace('inferred type', workspace => {
+    onWorkspace('output parametric type', workspace => {
+      const id = workspace.newBlock('id')
+      assertType(id, 'a', 'a')
+    })
+
+    onWorkspace('inferred input type', workspace => {
       const compare = workspace.newBlock('compare')
       const number = workspace.newBlock('math_number')
       connect(compare, number, 0)
       assertType(compare, 'Number', 'Boolean')
+    })
+
+    onWorkspace('inferred output type', workspace => {
+      const id = workspace.newBlock('id')
+      const number = workspace.newBlock('math_number')
+      connect(id, number, 0)
+      assertType(id, 'Number')
     })
   })
 


### PR DESCRIPTION
- Add parametric type declaration for `compare` and `id` functions (`composition` and higher order functions are out of scope)
- Add parametric type inference by substitute variable types
- Change `checkType` (Blockly) algorithm 
- `npm start` create `index.html` from `index.md` for local development
- Max sized workspace

![Peek 2020-04-19 05-57](https://user-images.githubusercontent.com/4098184/79683824-05150d80-8203-11ea-948b-d25a9a633663.gif)
