### PR TITLE
Decouple our own types from Blockly Types

### DIFF
--- a/src/colors.js
+++ b/src/colors.js
@@ -6,7 +6,7 @@ const typeColors = {
   'Any': defaultColor
 }
 
-const colorType = (block) => typeToColor(functionType(block))
+const colorType = (block) => typeToColor(blockType(block))
 
 const typeToColor = (type) => {
   if (isFunction(type)) return interpolateColors(functionTypeToList(type))

--- a/src/functions.js
+++ b/src/functions.js
@@ -6,7 +6,7 @@ function onChangeValue(event) {
 }
 
 function onChangeFunction(event) {
-  if (this.getParent() && isFunction(functionType(this))) {
+  if (this.getParent() && isFunction(blockType(this))) {
     this.setCollapsed(true)
   } else {
     this.setCollapsed(false)
@@ -31,63 +31,74 @@ function onChangeComposition(event) {
   }
 }
 
+function setFunctionType(block, ...types) {
+  const outputType = types.slice(-1)[0];
+  const inputTypes = types.slice(0, -1);
+
+  inputTypes.forEach((inputType, i) => { block.inputList[i].inputType = inputType });
+  block.outputType = outputType;
+}
+
 Blockly.Blocks['even'] = {
   init: function () {
     this.appendValueInput("NAME")
-      .setCheck("Number")
       .appendField("even");
     this.setInputsInline(true);
-    this.setOutput(true, "Boolean");
+    this.setOutput(true);
     this.setColour(230);
     this.setTooltip("");
     this.setHelpUrl("");
     this.setOnChange(onChangeFunction.bind(this))
+
+    setFunctionType(this, "Number", "Boolean")
   }
 }
 
 Blockly.Blocks['not'] = {
   init: function () {
     this.appendValueInput("NAME")
-      .setCheck("Boolean")
       .appendField("not");
     this.setInputsInline(true);
-    this.setOutput(true, "Boolean");
+    this.setOutput(true);
     this.setColour(230);
     this.setTooltip("");
     this.setHelpUrl("");
     this.setOnChange(onChangeFunction.bind(this))
+
+    setFunctionType(this, "Boolean", "Boolean")
   }
 }
 
 Blockly.Blocks['length'] = {
   init: function () {
     this.appendValueInput("NAME")
-      .setCheck("String")
       .appendField("length");
     this.setInputsInline(true);
-    this.setOutput(true, "Number");
+    this.setOutput(true);
     this.setColour(230);
     this.setTooltip("");
     this.setHelpUrl("");
     this.setOnChange(onChangeFunction.bind(this))
+
+    setFunctionType(this, "String", "Number")
   }
 }
 
 Blockly.Blocks['charAt'] = {
   init: function () {
     this.appendValueInput("NAME")
-      .setCheck("Number")
       .appendField("charAt");
 
     this.appendValueInput("NAME")
-      .setCheck("String")
 
     this.setInputsInline(true);
-    this.setOutput(true, "String");
+    this.setOutput(true);
     this.setColour(230);
     this.setTooltip("");
     this.setHelpUrl("");
     this.setOnChange(onChangeFunction.bind(this))
+
+    setFunctionType(this, "Number", "String", "String")
   }
 }
 
@@ -99,15 +110,14 @@ Blockly.Blocks['compare'] = {
       .appendField(">");//TODO: Selector
 
     this.setInputsInline(true);
-    this.setOutput(true, "Boolean");
+    this.setOutput(true);
     this.setColour(230);
     this.setTooltip("");
     this.setHelpUrl("");
     this.setOnChange(onChangeFunction.bind(this))
 
     //Parametric Type
-    this.inputList[0].parametricType = 'a'
-    this.inputList[1].parametricType = 'a'
+    setFunctionType(this, "a", "a", "Boolean")
   }
 }
 
@@ -124,8 +134,7 @@ Blockly.Blocks['id'] = {
     this.setOnChange(onChangeFunction.bind(this))
 
     //Parametric Type
-    this.inputList[0].parametricType = 'a'
-    this.parametricType = 'a'
+    setFunctionType(this, "a", "a")
   }
 }
 

--- a/src/typeSystem.js
+++ b/src/typeSystem.js
@@ -6,7 +6,7 @@ const asFunctionType = (...types) => types.join('->')
 
 const functionTypeToList = functionType => functionType.split('->')
 
-function functionType(functionBlock) {
+function blockType(functionBlock) {
   const inputTypes = functionBlock.inputList
     .filter(isEmptyBlockInput)
     .map(input => getInputType(input))
@@ -14,7 +14,7 @@ function functionType(functionBlock) {
 }
 
 function outputFunctionType(functionBlock) {
-  const type = functionType(functionBlock)
+  const type = blockType(functionBlock)
   if (!isFunction(type)) return null
   return asFunctionType(...functionTypeToList(type).slice(1))
 }
@@ -23,10 +23,10 @@ function typeVariables(functionBlock) {
   const typeMap = {}
   functionBlock.inputList
     .filter(isFullyBlockInput)
-    .filter(input => input.parametricType)
+    .filter(input => input.inputType && isVarType(input.inputType))
     .forEach(input => {
-      const typeVar = input.parametricType
-      const type = functionType(input.connection.targetConnection.getSourceBlock())
+      const typeVar = input.inputType
+      const type = blockType(input.connection.targetConnection.getSourceBlock())
       if (type != 'Any') {
         typeMap[typeVar] = typeMap[typeVar] && typeMap[typeVar] != type ? 'ERROR' : type  //TODO: Type check? 
       }
@@ -35,23 +35,24 @@ function typeVariables(functionBlock) {
 }
 
 function getInputType(input) {
-  if (input.parametricType) {
+  if (input.inputType) {
     const typeMap = typeVariables(input.getSourceBlock())
-    return typeMap[input.parametricType] || input.parametricType
+    return typeMap[input.inputType] || input.inputType
   }
 
   return getType(input.connection)
 }
 
 function getOutputType(block) {
-  if (block.parametricType) {
+  if (block.outputType) {
     const typeMap = typeVariables(block)
-    return typeMap[block.parametricType] || block.parametricType
+    return typeMap[block.outputType] || block.outputType
   }
 
   return getType(block.outputConnection)
 }
 
 function getType(connection) {
+  
   return connection.getCheck() && connection.getCheck()[0] || 'Any'
 }

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,12 +1,7 @@
-
-function checkConnectionType(connection, block, getType = functionType) {
-  return connection.checkType({ check_: [getType(block)] })
-}
-
 function checkInputType(input, block) {
-  const inputType = getInputType(input)
-  const blockType = functionType(block)
-  const types = [inputType, blockType]
+  const expectedType = getInputType(input)
+  const actualType = blockType(block)
+  const types = [expectedType, actualType]
   return !types.includes('Error') && (types.includes('Any') || matchTypes(...types))
 }
 
@@ -30,12 +25,12 @@ function firstEmptyInput(block) {
 
 function matchCompositionType(block1, block2) {
   const input = firstEmptyInput(block1)
-  return input && checkConnectionType(input.connection, block2, outputFunctionType)
+  return input && matchTypes(getInputType(input), outputFunctionType(block2))
 }
 
 function matchApplyType(block1, block2) {
   const input = firstEmptyInput(block1)
-  return input && checkConnectionType(input.connection, block2)
+  return input && matchTypes(getInputType(input), blockType(block2))
 }
 
 function checkParentConnection(block) {
@@ -45,7 +40,7 @@ function checkParentConnection(block) {
 }
 
 function checkFunction(functionBlock) {
-  if (!isFunction(functionType(functionBlock))) {
+  if (!isFunction(blockType(functionBlock))) {
     bump(functionBlock)
   }
 }

--- a/test/typeSpec.js
+++ b/test/typeSpec.js
@@ -86,5 +86,5 @@ describe('Types', () => {
 })
 
 const assertType = (block, ...types) => {
-  assert.equal(functionType(block), asFunctionType(...types))
+  assert.equal(blockType(block), asFunctionType(...types))
 }


### PR DESCRIPTION
If we want to intersect and typecheck all applications ourselves, we'd have problems using Blockly types because some applications would be rejected by Blockly even before we can check the types ourselves. So if we wanted to return custom errors we woudln't be able to do so in the cases in which Blockly doesn't allow you to connect incompatible blocks.